### PR TITLE
Update ruby-bandwidth-iris.gemspec

### DIFF
--- a/ruby-bandwidth-iris.gemspec
+++ b/ruby-bandwidth-iris.gemspec
@@ -18,10 +18,10 @@ Gem::Specification.new do |spec|
   spec.add_dependency "faraday"
   spec.add_dependency "faraday_middleware"
   spec.add_dependency "nori"
-  spec.add_dependency "activesupport","4.2.7"
+  spec.add_dependency "activesupport",">= 4.2.7"
   spec.add_dependency "certified"
 
-  spec.add_development_dependency "bundler", "~> 1.3"
-  spec.add_development_dependency "rake", "11.1.0"
+  spec.add_development_dependency "bundler", ">= 1.3"
+  spec.add_development_dependency "rake", ">= 11.1.0"
   spec.add_development_dependency "yard"
 end


### PR DESCRIPTION
I was unable to install the gem with Rails 5.2. This should help.