### PR TITLE
Fix deprecated Faraday basic_auth

### DIFF
--- a/lib/bandwidth-iris/client.rb
+++ b/lib/bandwidth-iris/client.rb
@@ -28,7 +28,7 @@ module BandwidthIris
       @set_adapter = lambda {|faraday| faraday.adapter(Faraday.default_adapter)}
       @create_connection = lambda{||
         Faraday.new(api_endpoint) { |faraday|
-          faraday.basic_auth(user_name, password)
+          faraday.request :basic_auth, user_name, password
           #faraday.response :logger
           faraday.headers['Accept'] = 'application/xml'
           faraday.headers['user-agent'] = 'Ruby-Bandwidth-Iris'

--- a/spec/bandwidth-iris/client_spec.rb
+++ b/spec/bandwidth-iris/client_spec.rb
@@ -46,7 +46,6 @@ describe BandwidthIris::Client do
     it 'should create new faraday connection' do
       connection = client.create_connection()
       expect(connection).to be_a(Faraday::Connection)
-      expect(connection.headers['Authorization']).to eql("Basic #{Base64.strict_encode64('username:password')}")
     end
   end
 
@@ -58,6 +57,12 @@ describe BandwidthIris::Client do
 
     after :each do
       client.stubs.verify_stubbed_calls()
+    end
+
+    it 'should pass basic auth headers' do
+      # Note: This endpoint does not exist. It is stubbed in order to echo back the Authorization headers that are added by Faraday middleware.
+      client.stubs.get('/v1.0/test-auth') { |env| [200, {}, "<Result><EchoedAuth>#{env[:request_headers]['Authorization']}</EchoedAuth></Result>"] }
+      expect(client.make_request(:get, '/test-auth')).to eql([{:echoed_auth=>"Basic #{Base64.strict_encode64('username:password')}"}, {}])
     end
 
     it 'should make GET request and return xml  data' do


### PR DESCRIPTION
Hi there :wave:

We're using your library in our stack and have noticed that there are now warnings being thrown for usage of deprecated Faraday methods.

Specifically:
```
WARNING: `Faraday::Connection#basic_auth` is deprecated; it will be removed in version 2.0.
While initializing your connection, use `#request(:basic_auth, ...)` instead.
See https://lostisland.github.io/faraday/middleware/authentication for more usage info.
```

This PR updates the usage of `basic_auth` to be in line with the suggestion at [that link](https://lostisland.github.io/faraday/middleware/authentication).

I searched for other usages of `basic_auth` in here but this seems to be the only instance.

The specs ended up getting a little funky since this new approach adds the auth at the middleware level and not on the connection itself. This means that the **Authorization** headers don't exist on the connection, but are added once the request is in flight. I modified the specs to use an approach [used by Faraday itself](https://github.com/lostisland/faraday/blob/23e249563613971ced8f851230c46b9eeeefe931/spec/faraday/request/authorization_spec.rb).

Please let me know if you have any questions and thanks for the consideration!