### PR TITLE
Support later versions of Active Support + Ruby 3

### DIFF
--- a/lib/bandwidth-iris/client.rb
+++ b/lib/bandwidth-iris/client.rb
@@ -1,5 +1,6 @@
 require 'faraday'
 require 'faraday_middleware'
+require 'active_support'
 require 'active_support/xml_mini'
 require 'active_support/core_ext/hash/conversions'
 require 'active_support/core_ext/string/inflections'

--- a/ruby-bandwidth-iris.gemspec
+++ b/ruby-bandwidth-iris.gemspec
@@ -18,7 +18,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency "faraday"
   spec.add_dependency "faraday_middleware"
   spec.add_dependency "nori"
-  spec.add_dependency "activesupport", "~> 4.2.7"
+  spec.add_dependency "activesupport",">= 4.2.7"
+  spec.add_dependency "rexml"
 
   spec.add_development_dependency "bundler", ">= 1.3"
   spec.add_development_dependency "rake", ">= 11.1.0"


### PR DESCRIPTION
Hey all,

Thank you so much for merging #54! It looks like the changes included in that gem release broke our stack though. Would you please consider this fix, which should hopefully support all versions?

## Problem
We're running Rails 6 so pinning to `active_support ~> 4.2.7` gives us an incompatible gem issue since `active_support` is versioned with Rails (the current version is 7+). Since Rails depends on `active_support`, there is no way to support 4.2.x when Rails requires 6.x (or 7.x in the latest release).

## Solution
Because the usage of `active_support` in this library is fairly limited, there seems to be no issue supporting later versions. The modifications required are in this PR.

I tested this PR on Ruby 2.7.5 and Ruby 3.0.3 and it seems to fix the issues across the board. 

Please note that `rexml` is now specified as a dependency. Starting in Ruby 3, it was [no longer included as a default gem](https://stackoverflow.com/questions/65479863/rails-6-1-ruby-3-0-0-tests-error-as-they-cannot-load-rexml). So the dependency was always there, but now we need to explicitly pull it in if needed.