### PR TITLE
Add compatibility with faraday 2

### DIFF
--- a/lib/bandwidth-iris/client.rb
+++ b/lib/bandwidth-iris/client.rb
@@ -1,4 +1,5 @@
 require 'faraday'
+require 'base64'
 require 'faraday/follow_redirects'
 require 'active_support'
 require 'active_support/xml_mini'
@@ -29,7 +30,8 @@ module BandwidthIris
       @set_adapter = lambda {|faraday| faraday.adapter(Faraday.default_adapter)}
       @create_connection = lambda{||
         Faraday.new(api_endpoint) { |faraday|
-          faraday.request :basic_auth, user_name, password
+          # To make this gem compatible with Faraday v1 and v2, the basic_auth middleware can't be used because it was removed in v2
+          faraday.request :authorization, 'Basic', Base64.strict_encode64("#{user_name}:#{password}")
           #faraday.response :logger
           faraday.headers['Accept'] = 'application/xml'
           faraday.headers['user-agent'] = 'Ruby-Bandwidth-Iris'

--- a/lib/bandwidth-iris/client.rb
+++ b/lib/bandwidth-iris/client.rb
@@ -1,5 +1,5 @@
 require 'faraday'
-require 'faraday_middleware'
+require 'faraday/follow_redirects'
 require 'active_support'
 require 'active_support/xml_mini'
 require 'active_support/core_ext/hash/conversions'
@@ -33,7 +33,7 @@ module BandwidthIris
           #faraday.response :logger
           faraday.headers['Accept'] = 'application/xml'
           faraday.headers['user-agent'] = 'Ruby-Bandwidth-Iris'
-          faraday.use FaradayMiddleware::FollowRedirects
+          faraday.response :follow_redirects # use Faraday::FollowRedirects::Middleware
           @set_adapter.call(faraday)
         }
       }

--- a/ruby-bandwidth-iris.gemspec
+++ b/ruby-bandwidth-iris.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.add_dependency "builder"
   spec.add_dependency "faraday"
-  spec.add_dependency "faraday_middleware"
+  spec.add_dependency "faraday-follow_redirects", '~> 0.3.0'
   spec.add_dependency "nori"
   spec.add_dependency "activesupport",">= 4.2.7"
   spec.add_dependency "rexml"


### PR DESCRIPTION
The version of `faraday` is currently not pinned to v1 on the gemspec, but because of the dependency with `faraday_middleware` (which is only available for v1), v2 cannot be used. 
This PR replaces that dependency with `faraday-follow_redirects` which works with v1 and v2, and also sets the `Authorization` header in a way that works for both versions of faraday.