### PR TITLE
size and page parameters are required for this endpoint.

### DIFF
--- a/lib/bandwidth-iris/site.rb
+++ b/lib/bandwidth-iris/site.rb
@@ -69,8 +69,8 @@ module BandwidthIris
       list
     end
 
-    def get_orders()
-      list = @client.make_request(:get, "#{@client.concat_account_path(SITE_PATH)}/#{id}/orders")[0]
+    def get_orders(size: 30, page: 1)
+      list = @client.make_request(:get, "#{@client.concat_account_path(SITE_PATH)}/#{id}/orders", {size:, page:})[0]
       # TODO need additional documentaion
       list
     end


### PR DESCRIPTION
Without these parameters the Bandwidth API returns a 400 response. 

This code likely never worked as written, but does return a response now. 