### PR TITLE
Remove nori as gem dependency

### DIFF
--- a/ruby-bandwidth-iris.gemspec
+++ b/ruby-bandwidth-iris.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "builder"
   spec.add_dependency "faraday"
   spec.add_dependency "faraday-follow_redirects", '~> 0.3.0'
-  spec.add_dependency "nori"
   spec.add_dependency "activesupport",">= 4.2.7"
   spec.add_dependency "rexml"
 


### PR DESCRIPTION
It looks to me like this dependency is not used anywhere. Tests work locally without it.

Please let me know if I've missed where/how it's being used, couldn't find anything in the git history besides the initial commit that added it in the gemspec.