### PR TITLE
Sync bandwidth.com/languages annotation to Backstage catalog

### DIFF
--- a/.bandwidth/component.yaml
+++ b/.bandwidth/component.yaml
@@ -7,6 +7,7 @@ metadata:
     Ruby SDK for Bandwidth Phone Number Dashboard (AKA: Dashboard, Iris)
   annotations:
     github.com/project-slug: Bandwidth/ruby-bandwidth-iris
+    bandwidth.com/languages: Ruby
     organization: BW
     costCenter: Development - Software Infra
 spec:


### PR DESCRIPTION
Syncs the `bandwidth.com/languages` annotation in `.bandwidth/component.yaml` to match the repository's actual detected languages.

See: https://bandwidth-jira.atlassian.net/browse/SWI-11736

**Language change:** `(none)` → `Ruby`